### PR TITLE
Bug/7 non scalar query in dapper requires access to dbtransaction

### DIFF
--- a/Promethix.Framework.Ado.Tests/IntegrationTests/AdoScopeMssqlTests.cs
+++ b/Promethix.Framework.Ado.Tests/IntegrationTests/AdoScopeMssqlTests.cs
@@ -42,13 +42,8 @@ namespace Promethix.Framework.Ado.Tests.IntegrationTests
         [TestCategory("IntegrationTests"), TestMethod]
         public void MssqlAdoScopeBasicReadRecordsTest()
         {
-            using IAdoScope adoScopePrepare = adoScopeFactory.Create();
-            var newTestEntity = new TestEntity { Name = "CreateTest", Description = "Test Description", Quantity = 1 };
-            simpleTestRepository.Add(newTestEntity);
-            adoScopePrepare.Complete();
-
             using IAdoScope adoScope = adoScopeFactory.Create();
-            Assert.IsTrue(simpleTestRepository.GetEntities().Any());
+            Assert.IsFalse(simpleTestRepository.GetEntities().Any());
             adoScope.Complete();
         }
 

--- a/Promethix.Framework.Ado.Tests/IntegrationTests/AdoScopeMssqlTests.cs
+++ b/Promethix.Framework.Ado.Tests/IntegrationTests/AdoScopeMssqlTests.cs
@@ -40,6 +40,19 @@ namespace Promethix.Framework.Ado.Tests.IntegrationTests
         }
 
         [TestCategory("IntegrationTests"), TestMethod]
+        public void MssqlAdoScopeBasicReadRecordsTest()
+        {
+            using IAdoScope adoScopePrepare = adoScopeFactory.Create();
+            var newTestEntity = new TestEntity { Name = "CreateTest", Description = "Test Description", Quantity = 1 };
+            simpleTestRepository.Add(newTestEntity);
+            adoScopePrepare.Complete();
+
+            using IAdoScope adoScope = adoScopeFactory.Create();
+            Assert.IsTrue(simpleTestRepository.GetEntities().Any());
+            adoScope.Complete();
+        }
+
+        [TestCategory("IntegrationTests"), TestMethod]
         public void MssqlAdoScopeBasicTest()
         {
 

--- a/Promethix.Framework.Ado.Tests/TestSupport/DataAccess/Mssql/ISimpleMssqlTestRepository.cs
+++ b/Promethix.Framework.Ado.Tests/TestSupport/DataAccess/Mssql/ISimpleMssqlTestRepository.cs
@@ -13,6 +13,8 @@ namespace Promethix.Framework.Ado.Tests.TestSupport.DataAccess.Mssql
 
         TestEntity GetEntityByName(string name);
 
+        IEnumerable<TestEntity> GetEntities();
+
         void AddWithDifferentContext(TestEntity entity);
 
         int GetEntityCount();

--- a/Promethix.Framework.Ado.Tests/TestSupport/DataAccess/Mssql/MssqlContextExample3.cs
+++ b/Promethix.Framework.Ado.Tests/TestSupport/DataAccess/Mssql/MssqlContextExample3.cs
@@ -1,0 +1,23 @@
+﻿using Promethix.Framework.Ado.Enums;
+using Promethix.Framework.Ado.Implementation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Promethix.Framework.Ado.Tests.TestSupport.DataAccess.Mssql
+{
+    public class MssqlContextExample3 : AdoContext
+    {
+        public MssqlContextExample3()
+            : base(
+                "MssqlContextExample3",
+                "Microsoft.Data.SqlClient",
+                "Server=(local);Database=AdoScopeTest1;Integrated Security=True;TrustServerCertificate=True",
+                AdoContextExecutionOption.Transactional)
+        {
+            // No Implementation
+        }
+    }
+}

--- a/Promethix.Framework.Ado.Tests/TestSupport/DataAccess/Mssql/SimpleMssqlTestRepository.cs
+++ b/Promethix.Framework.Ado.Tests/TestSupport/DataAccess/Mssql/SimpleMssqlTestRepository.cs
@@ -26,6 +26,8 @@ namespace Promethix.Framework.Ado.Tests.TestSupport.DataAccess.Mssql
 
         private IDbConnection SqlConnection3 => ambientAdoContextLocator.GetContext<MssqlContextExample3>().Connection;
 
+        private IDbTransaction SqlTransaction3 => ambientAdoContextLocator.GetContext<MssqlContextExample3>().Transaction;
+
         public void Add(TestEntity entity)
         {
             const string query = "INSERT INTO TestEntity (Name, Description, Quantity) VALUES (@Name, @Description, @Quantity)";
@@ -47,7 +49,7 @@ namespace Promethix.Framework.Ado.Tests.TestSupport.DataAccess.Mssql
         public IEnumerable<TestEntity> GetEntities()
         {
             const string query = "SELECT * FROM TestEntity";
-            return SqlConnection3.Query<TestEntity>(query);
+            return SqlConnection3.Query<TestEntity>(query, transaction: SqlTransaction3);
         }
 
         public int GetEntityCount()

--- a/Promethix.Framework.Ado.Tests/TestSupport/DataAccess/Mssql/SimpleMssqlTestRepository.cs
+++ b/Promethix.Framework.Ado.Tests/TestSupport/DataAccess/Mssql/SimpleMssqlTestRepository.cs
@@ -24,6 +24,8 @@ namespace Promethix.Framework.Ado.Tests.TestSupport.DataAccess.Mssql
 
         private IDbConnection SqlConnection2 => ambientAdoContextLocator.GetContext<MssqlContextExample2>().Connection;
 
+        private IDbConnection SqlConnection3 => ambientAdoContextLocator.GetContext<MssqlContextExample3>().Connection;
+
         public void Add(TestEntity entity)
         {
             const string query = "INSERT INTO TestEntity (Name, Description, Quantity) VALUES (@Name, @Description, @Quantity)";
@@ -40,6 +42,12 @@ namespace Promethix.Framework.Ado.Tests.TestSupport.DataAccess.Mssql
         {
             const string query = "SELECT * FROM TestEntity WHERE Name = @Name";
             return SqlConnection1.QuerySingleOrDefault<TestEntity>(query, new { Name = name });
+        }
+
+        public IEnumerable<TestEntity> GetEntities()
+        {
+            const string query = "SELECT * FROM TestEntity";
+            return SqlConnection3.Query<TestEntity>(query);
         }
 
         public int GetEntityCount()

--- a/Promethix.Framework.Ado/Implementation/AdoContext.cs
+++ b/Promethix.Framework.Ado/Implementation/AdoContext.cs
@@ -38,6 +38,23 @@ namespace Promethix.Framework.Ado.Implementation
             }
         }
 
+        /// <summary>
+        /// Gets the transaction for reference. 
+        /// WARNING: This should not be used to commit or rollback the transaction!
+        /// </summary>
+        public IDbTransaction Transaction
+        {
+            get
+            {
+                if (transaction == null)
+                {
+                    throw new InvalidOperationException("There is no active transaction.");
+                }
+
+                return transaction;
+            }
+        }
+
         protected AdoContext()
         {
             // No Implementation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build and Test 0.1.x-alpha](https://github.com/gentoorax/Promethix.Framework.Ado/actions/workflows/adoscope-nuget-build.yaml/badge.svg)](https://github.com/gentoorax/Promethix.Framework.Ado/actions/workflows/adoscope-nuget-build.yaml)
 [![Published to nuget.org 0.1.x-x-alpha](https://github.com/gentoorax/Promethix.Framework.Ado/actions/workflows/adoscope-nuget-publish-prerelease.yaml/badge.svg)](https://github.com/gentoorax/Promethix.Framework.Ado/actions/workflows/adoscope-nuget-publish-prerelease.yaml)
 
-**Recently promoted to v1.0.0-rc2. All major features have been implemented.**
+**Recently promoted to v1.0.0-rc3. All major features have been implemented.**
 
 **Now incldues .NET 8.0 support**
 


### PR DESCRIPTION
Exposed the transaction object as it's required to be passed explicitly for when using Dapper and generating SqlCommand objects. This transaction object should not be used to commit or rollback the transaction and is for reference in SqlCommand and Dapper .Query only.